### PR TITLE
Fix syntax error in download_model.sh

### DIFF
--- a/download_model.sh
+++ b/download_model.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-if [[ ! -f 'colornet.t7' ]]; then
+if [ ! -f 'colornet.t7' ]; then
    echo "Downloading the colorization model..."
    wget "http://hi.cs.waseda.ac.jp/~iizuka/data/colornet.t7"
 else


### PR DESCRIPTION
`/bin/sh` does not support the double bracket([[) command on some platforms.

On Ubuntu 15.10:
```
% ./download_model.sh    
./download_model.sh: 2: ./download_model.sh: [[: not found
Model file already exists!
```